### PR TITLE
make aes-cmac browser-compatible

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 18
+    - run: npm ci
+    - run: npm run build
+    - run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 /lib
 /node_modules
-
+.log

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,10 @@
       "name": "aes-cmac",
       "version": "1.0.3",
       "license": "MIT",
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "one-webcrypto": "^1.0.3"
+      },
       "devDependencies": {
         "@types/node": "^16.11.17",
         "mocha": "^9.1.3",
@@ -75,6 +79,25 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -111,6 +134,29 @@
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -412,6 +458,25 @@
         "he": "bin/he"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -645,6 +710,11 @@
       "dependencies": {
         "wrappy": "1"
       }
+    },
+    "node_modules/one-webcrypto": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/one-webcrypto/-/one-webcrypto-1.0.3.tgz",
+      "integrity": "sha512-fu9ywBVBPx0gS9K0etIROTiCkvI5S1TDjFsYFb3rC1ewFxeOqsbzq7aIMBHsYfrTHBcGXJaONXXjTl8B01cW1Q=="
     },
     "node_modules/p-limit": {
       "version": "3.0.2",
@@ -1081,6 +1151,11 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
     "binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -1111,6 +1186,15 @@
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
+    },
+    "buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "requires": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
     },
     "chalk": {
       "version": "4.1.2",
@@ -1330,6 +1414,11 @@
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -1500,6 +1589,11 @@
       "requires": {
         "wrappy": "1"
       }
+    },
+    "one-webcrypto": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/one-webcrypto/-/one-webcrypto-1.0.3.tgz",
+      "integrity": "sha512-fu9ywBVBPx0gS9K0etIROTiCkvI5S1TDjFsYFb3rC1ewFxeOqsbzq7aIMBHsYfrTHBcGXJaONXXjTl8B01cW1Q=="
     },
     "p-limit": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -30,5 +30,9 @@
     "@types/node": "^16.11.17",
     "mocha": "^9.1.3",
     "typescript": "^4.5.4"
+  },
+  "dependencies": {
+    "buffer": "^6.0.3",
+    "one-webcrypto": "^1.0.3"
   }
 }

--- a/test/AesCmac.js
+++ b/test/AesCmac.js
@@ -1,138 +1,191 @@
-const AesCmac = require('../lib/AesCmac.js').AesCmac;
-const assert = require('assert');
+const AesCmac = require("../lib/AesCmac.js").AesCmac;
+const assert = require("assert");
 
-describe('aes-cmac', () => {
-  describe('NIST 800-38B test vectors', () => {
+describe("aes-cmac", () => {
+  describe("NIST 800-38B test vectors", () => {
     const keys = {
-      '128': Buffer.from('2b7e151628aed2a6abf7158809cf4f3c', 'hex'),
-      '192': Buffer.from('8e73b0f7da0e6452c810f32b809079e562f8ead2522c6b7b', 'hex'),
-      '256': Buffer.from('603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4', 'hex'),
+      128: Buffer.from("2b7e151628aed2a6abf7158809cf4f3c", "hex"),
+      192: Buffer.from(
+        "8e73b0f7da0e6452c810f32b809079e562f8ead2522c6b7b",
+        "hex"
+      ),
+      256: Buffer.from(
+        "603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4",
+        "hex"
+      ),
     };
 
-    describe('generateSubkeys(key)', () => {
-      it('creates the correct subkeys for a 128 bit key', () => {
+    describe("generateSubkeys(key)", () => {
+      it("creates the correct subkeys for a 128 bit key", async () => {
         const expected = {
-          key1: Buffer.from('fbeed618357133667c85e08f7236a8de', 'hex'),
-          key2: Buffer.from('f7ddac306ae266ccf90bc11ee46d513b', 'hex')
+          key1: Buffer.from("fbeed618357133667c85e08f7236a8de", "hex"),
+          key2: Buffer.from("f7ddac306ae266ccf90bc11ee46d513b", "hex"),
         };
-        const aesCmac = new AesCmac(keys['128']);
-        const result = aesCmac.getSubKeys();
+        const aesCmac = new AesCmac(keys["128"]);
+        const result = await aesCmac.getSubKeys();
         assert.deepStrictEqual(result, expected);
       });
 
-      it('creates the correct subkeys for a 192 bit key', () => {
+      it("creates the correct subkeys for a 192 bit key", async () => {
         const expected = {
-          key1: Buffer.from('448a5b1c93514b273ee6439dd4daa296', 'hex'),
-          key2: Buffer.from('8914b63926a2964e7dcc873ba9b5452c', 'hex')
+          key1: Buffer.from("448a5b1c93514b273ee6439dd4daa296", "hex"),
+          key2: Buffer.from("8914b63926a2964e7dcc873ba9b5452c", "hex"),
         };
-        const aesCmac = new AesCmac(keys['192']);
-        const result = aesCmac.getSubKeys();
+        const aesCmac = new AesCmac(keys["192"]);
+        const result = await aesCmac.getSubKeys();
         assert.deepStrictEqual(result, expected);
       });
 
-      it('creates the correct subkeys for a 256 bit key', () => {
+      it("creates the correct subkeys for a 256 bit key", async () => {
         const expected = {
-          key1: Buffer.from('cad1ed03299eedac2e9a99808621502f', 'hex'),
-          key2: Buffer.from('95a3da06533ddb585d3533010c42a0d9', 'hex')
+          key1: Buffer.from("cad1ed03299eedac2e9a99808621502f", "hex"),
+          key2: Buffer.from("95a3da06533ddb585d3533010c42a0d9", "hex"),
         };
-        const aesCmac = new AesCmac(keys['256']);
-        const result = aesCmac.getSubKeys();
+        const aesCmac = new AesCmac(keys["256"]);
+        const result = await aesCmac.getSubKeys();
         assert.deepStrictEqual(result, expected);
       });
     });
 
-    describe('aesCmac(key, message)', () => {
+    describe("aesCmac(key, message)", () => {
       const messages = {
-        length0: Buffer.from('', 'hex'),
-        length128: Buffer.from('6bc1bee22e409f96e93d7e117393172a', 'hex'),
-        length320: Buffer.from('6bc1bee22e409f96e93d7e117393172aae2d8a57' +
-                              '1e03ac9c9eb76fac45af8e5130c81c46a35ce411', 'hex'),
-        length512: Buffer.from('6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e51' +
-                              '30c81c46a35ce411e5fbc1191a0a52eff69f2445df4f9b17ad2b417be66c3710', 'hex')
+        length0: Buffer.from("", "hex"),
+        length128: Buffer.from("6bc1bee22e409f96e93d7e117393172a", "hex"),
+        length320: Buffer.from(
+          "6bc1bee22e409f96e93d7e117393172aae2d8a57" +
+            "1e03ac9c9eb76fac45af8e5130c81c46a35ce411",
+          "hex"
+        ),
+        length512: Buffer.from(
+          "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e51" +
+            "30c81c46a35ce411e5fbc1191a0a52eff69f2445df4f9b17ad2b417be66c3710",
+          "hex"
+        ),
       };
 
-      it('generates the authentiation code for length 0 input, 128 bit key', () => {
-        const aesCmac = new AesCmac(keys['128']);
-        const result = aesCmac.calculate(messages.length0);
-        assert.strictEqual(result.toString('hex'), 'bb1d6929e95937287fa37d129b756746');
+      it("generates the authentiation code for length 0 input, 128 bit key", async () => {
+        const aesCmac = new AesCmac(keys["128"]);
+        const result = await aesCmac.calculate(messages.length0);
+        assert.strictEqual(
+          result.toString("hex"),
+          "bb1d6929e95937287fa37d129b756746"
+        );
       });
 
-      it('generates the authentiation code for length 0 input, 192 bit key', () => {
-        const aesCmac = new AesCmac(keys['192']);
-        const result = aesCmac.calculate(messages.length0);
-        assert.strictEqual(result.toString('hex'), 'd17ddf46adaacde531cac483de7a9367');
+      it("generates the authentiation code for length 0 input, 192 bit key", async () => {
+        const aesCmac = new AesCmac(keys["192"]);
+        const result = await aesCmac.calculate(messages.length0);
+        assert.strictEqual(
+          result.toString("hex"),
+          "d17ddf46adaacde531cac483de7a9367"
+        );
       });
 
-      it('generates the authentiation code for length 0 input, 256 bit key', () => {
-        const aesCmac = new AesCmac(keys['256']);
-        const result = aesCmac.calculate(messages.length0);
-        assert.strictEqual(result.toString('hex'), '028962f61b7bf89efc6b551f4667d983');
+      it("generates the authentiation code for length 0 input, 256 bit key", async () => {
+        const aesCmac = new AesCmac(keys["256"]);
+        const result = await aesCmac.calculate(messages.length0);
+        assert.strictEqual(
+          result.toString("hex"),
+          "028962f61b7bf89efc6b551f4667d983"
+        );
       });
 
-      it('generates the authentication code for length 128 input, 128 bit key', () => {
-        const aesCmac = new AesCmac(keys['128']);
-        const result = aesCmac.calculate(messages.length128);
-        assert.strictEqual(result.toString('hex'), '070a16b46b4d4144f79bdd9dd04a287c');
+      it("generates the authentication code for length 128 input, 128 bit key", async () => {
+        const aesCmac = new AesCmac(keys["128"]);
+        const result = await aesCmac.calculate(messages.length128);
+        assert.strictEqual(
+          result.toString("hex"),
+          "070a16b46b4d4144f79bdd9dd04a287c"
+        );
       });
 
-      it('generates the authentication code for length 128 input, 192 bit key', () => {
-        const aesCmac = new AesCmac(keys['192']);
-        const result = aesCmac.calculate(messages.length128);
-        assert.strictEqual(result.toString('hex'), '9e99a7bf31e710900662f65e617c5184');
+      it("generates the authentication code for length 128 input, 192 bit key", async () => {
+        const aesCmac = new AesCmac(keys["192"]);
+        const result = await aesCmac.calculate(messages.length128);
+        assert.strictEqual(
+          result.toString("hex"),
+          "9e99a7bf31e710900662f65e617c5184"
+        );
       });
 
-      it('generates the authentication code for length 128 input, 256 bit key', () => {
-        const aesCmac = new AesCmac(keys['256']);
-        const result = aesCmac.calculate(messages.length128);
-        assert.strictEqual(result.toString('hex'), '28a7023f452e8f82bd4bf28d8c37c35c');
+      it("generates the authentication code for length 128 input, 256 bit key", async () => {
+        const aesCmac = new AesCmac(keys["256"]);
+        const result = await aesCmac.calculate(messages.length128);
+        assert.strictEqual(
+          result.toString("hex"),
+          "28a7023f452e8f82bd4bf28d8c37c35c"
+        );
       });
 
-      it('generates the authentication code for length 320 input, 128 bit key', () => {
-        const aesCmac = new AesCmac(keys['128']);
-        const result = aesCmac.calculate(messages.length320);
-        assert.strictEqual(result.toString('hex'), 'dfa66747de9ae63030ca32611497c827');
+      it("generates the authentication code for length 320 input, 128 bit key", async () => {
+        const aesCmac = new AesCmac(keys["128"]);
+        const result = await aesCmac.calculate(messages.length320);
+        assert.strictEqual(
+          result.toString("hex"),
+          "dfa66747de9ae63030ca32611497c827"
+        );
       });
 
-      it('generates the authentication code for length 320 input, 192 bit key', () => {
-        const aesCmac = new AesCmac(keys['192']);
-        const result = aesCmac.calculate(messages.length320);
-        assert.strictEqual(result.toString('hex'), '8a1de5be2eb31aad089a82e6ee908b0e');
+      it("generates the authentication code for length 320 input, 192 bit key", async () => {
+        const aesCmac = new AesCmac(keys["192"]);
+        const result = await aesCmac.calculate(messages.length320);
+        assert.strictEqual(
+          result.toString("hex"),
+          "8a1de5be2eb31aad089a82e6ee908b0e"
+        );
       });
 
-      it('generates the authentication code for length 320 input, 256 bit key', () => {
-        const aesCmac = new AesCmac(keys['256']);
-        const result = aesCmac.calculate(messages.length320);
-        assert.strictEqual(result.toString('hex'), 'aaf3d8f1de5640c232f5b169b9c911e6');
+      it("generates the authentication code for length 320 input, 256 bit key", async () => {
+        const aesCmac = new AesCmac(keys["256"]);
+        const result = await aesCmac.calculate(messages.length320);
+        assert.strictEqual(
+          result.toString("hex"),
+          "aaf3d8f1de5640c232f5b169b9c911e6"
+        );
       });
 
-      it('generates the authentication code for length 512 input, 128 bit key', () => {
-        const aesCmac = new AesCmac(keys['128']);
-        const result = aesCmac.calculate(messages.length512);
-        assert.strictEqual(result.toString('hex'), '51f0bebf7e3b9d92fc49741779363cfe');
+      it("generates the authentication code for length 512 input, 128 bit key", async () => {
+        const aesCmac = new AesCmac(keys["128"]);
+        const result = await aesCmac.calculate(messages.length512);
+        assert.strictEqual(
+          result.toString("hex"),
+          "51f0bebf7e3b9d92fc49741779363cfe"
+        );
       });
 
-      it('generates the authentication code for length 512 input, 192 bit key', () => {
-        const aesCmac = new AesCmac(keys['192']);
-        const result = aesCmac.calculate(messages.length512);
-        assert.strictEqual(result.toString('hex'), 'a1d5df0eed790f794d77589659f39a11');
+      it("generates the authentication code for length 512 input, 192 bit key", async () => {
+        const aesCmac = new AesCmac(keys["192"]);
+        const result = await aesCmac.calculate(messages.length512);
+        assert.strictEqual(
+          result.toString("hex"),
+          "a1d5df0eed790f794d77589659f39a11"
+        );
       });
 
-      it('generates the authentication code for length 512 input, 256 bit key', () => {
-        const aesCmac = new AesCmac(keys['256']);
-        const result = aesCmac.calculate(messages.length512);
-        assert.strictEqual(result.toString('hex'), 'e1992190549f6ed5696a2c056c315410');
+      it("generates the authentication code for length 512 input, 256 bit key", async () => {
+        const aesCmac = new AesCmac(keys["256"]);
+        const result = await aesCmac.calculate(messages.length512);
+        assert.strictEqual(
+          result.toString("hex"),
+          "e1992190549f6ed5696a2c056c315410"
+        );
       });
     });
   });
 
-  describe('error handling', () => {
-    it('throws an error if the provided key is not a valid length', () => {
-      const key = Buffer.from('abcd');
-      const message = Buffer.from('some message');
-      assert.throws(() => new AesCmac(key), (error) => {
-        assert.strictEqual(error.message, 'Key size must be 128, 192, or 256 bits.');
-        return true;
-      });
+  describe("error handling", () => {
+    it("throws an error if the provided key is not a valid length", () => {
+      const key = Buffer.from("abcd");
+      assert.throws(
+        () => new AesCmac(key),
+        (error) => {
+          assert.strictEqual(
+            error.message,
+            "Key size must be 128, 192, or 256 bits."
+          );
+          return true;
+        }
+      );
     });
   });
 });

--- a/test/main.js
+++ b/test/main.js
@@ -1,47 +1,74 @@
-require('./BufferTools');
-require('./AesCmac');
+require("./BufferTools");
+require("./AesCmac");
 
-const AesCmac = require('../lib/AesCmac.js').AesCmac;
-const assert = require('assert');
+const AesCmac = require("../lib/AesCmac.js").AesCmac;
+const assert = require("assert");
 
-describe('index (module entry point)', () => {
-  describe('aesCmac(message)', () => {
-    it('performs the AES-CMAC algorithm', () => {
-      const key = Buffer.from('2b7e151628aed2a6abf7158809cf4f3c', 'hex');
-      const message = Buffer.from('6bc1bee22e409f96e93d7e117393172a', 'hex');
-      const result = new AesCmac(key).calculate(message);
-      assert.strictEqual(result.toString('hex'), '070a16b46b4d4144f79bdd9dd04a287c');
+describe("index (module entry point)", () => {
+  describe("aesCmac(message)", () => {
+    it("performs the AES-CMAC algorithm", async () => {
+      const key = Buffer.from("2b7e151628aed2a6abf7158809cf4f3c", "hex");
+      const message = Buffer.from("6bc1bee22e409f96e93d7e117393172a", "hex");
+      const result = await new AesCmac(key).calculate(message);
+      assert.strictEqual(
+        result.toString("hex"),
+        "070a16b46b4d4144f79bdd9dd04a287c"
+      );
     });
 
-    it('returns a buffer as the response', () => {
-      const key = Buffer.from('k3Men*p/2.3j4abB');
-      const message = Buffer.from('this|is|a|test|message');
-      const result = new AesCmac(key).calculate(message);
-      assert.strictEqual(result.toString('hex'), '0125c538f8be7c4eea370f992a4ffdcb');
+    it("returns a buffer as the response", async () => {
+      const key = Buffer.from("k3Men*p/2.3j4abB");
+      const message = Buffer.from("this|is|a|test|message");
+      const result = await new AesCmac(key).calculate(message);
+      assert.strictEqual(
+        result.toString("hex"),
+        "0125c538f8be7c4eea370f992a4ffdcb"
+      );
     });
 
-    it('throws an error if the key length is invalid', () => {
-      const expected = 'Key size must be 128, 192, or 256 bits.';
-      assertAesCmacError(Buffer.from('key'), Buffer.from('some message'), expected);
+    it("throws an error if the key length is invalid", () => {
+      const expected = "Key size must be 128, 192, or 256 bits.";
+      assertAesCmacError(
+        Buffer.from("key"),
+        Buffer.from("some message"),
+        expected
+      );
     });
 
-    it('throws an error if the key is not a Buffer', () => {
-      const expected = 'The key must be provided as a Buffer.';
-      assertAesCmacError(null, 'any message', expected);
-      assertAesCmacError(123, 'any message', expected);
+    it("throws an error if the key is not a Buffer", async () => {
+      const expected = "The key must be provided as a Buffer.";
+      assert.throws(
+        () => new AesCmac(10),
+        (error) => {
+          assert.equal(error.message, expected);
+          return true;
+        }
+      );
+      assert.throws(
+        () => new AesCmac(null),
+        (error) => {
+          assert.equal(error.message, expected);
+          return true;
+        }
+      );
     });
 
-    it('throws an error if the message is not a Buffer', () => {
-      const expected = 'The message must be provided as a Buffer.';
-      assertAesCmacError(Buffer.from('averysecretvalue'), null, expected);
-      assertAesCmacError(Buffer.from('averysecretvalue'), {}, expected);
+    it("throws an error if the message is not a Buffer", async () => {
+      const expected = "The message must be provided as a Buffer.";
+      await assertAesCmacError(Buffer.from("averysecretvalue"), null, expected);
+      await assertAesCmacError(Buffer.from("averysecretvalue"), {}, expected);
     });
 
-    function assertAesCmacError(key, message, expectedErrorMessage) {
-      assert.throws(() => new AesCmac(key).calculate(message), (error) => {
-        assert.strictEqual(error.message, expectedErrorMessage);
-        return true;
-      });
+    async function assertAesCmacError(key, message, expectedErrorMessage) {
+      await assert.rejects(
+        new AesCmac(key).calculate(message),
+
+        (error) => {
+          assert("message" in error);
+          assert.strictEqual(error.message, expectedErrorMessage);
+          return true;
+        }
+      );
     }
   });
 });


### PR DESCRIPTION
Closes #3 

A few notes:
* This is semver-major because webcrypto calls are async and that propagates through the interface
* My editor ran [`prettier`](https://prettier.io/) on this code, which was extracted from another codebase
* This PR adds two dependencies for browser compatability:
  * [`one-webcrypto`](https://github.com/fission-suite/one-webcrypto) which is just a shim because webcrypto is available through a different import path in browser and in node (even though it's the same native-implemented api)
  * [`buffer`](https://github.com/feross/buffer) so that no polyfilling is necessary to use this directly in either browsers or node.
* I added typescript's .log directory to gitignore
* I added a simple github workflow file to run tests in CI
  
All of the tests remain and pass.

Thanks!