### PR TITLE
Add main field for jest compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "aes-cmac",
   "version": "3.0.1",
+  "main": "lib/aes-cmac.cjs",
   "description": "AES-CMAC implementation in typescript",
   "types": "lib/aes-cmac.d.ts",
   "scripts": {


### PR DESCRIPTION
Jest seems unable to find aes-cmac without the main field.