### PR TITLE
Fix type exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "aes-cmac",
   "version": "3.0.2",
   "main": "lib/aes-cmac.cjs",
+  "module": "lib/aes-cmac.mjs",
   "description": "AES-CMAC implementation in typescript",
-  "types": "lib/aes-cmac.d.ts",
   "scripts": {
     "build": "rollup --config rollup.config.mjs",
     "test": "env TS_NODE_COMPILER_OPTIONS='{\"module\": \"commonjs\" }' mocha -r ts-node/register 'test/**/*.test.ts'",
@@ -27,8 +27,14 @@
     "test/**/*"
   ],
   "exports": {
-    "import": "./lib/aes-cmac.mjs",
-    "require": "./lib/aes-cmac.cjs"
+    "import": {
+      "types": "./lib/aes-cmac.d.mts",
+      "default": "./lib/aes-cmac.mjs"
+    },
+    "require": {
+      "types": "./lib/aes-cmac.d.cts",
+      "default": "./lib/aes-cmac.cjs"
+    }
   },
   "devDependencies": {
     "@types/mocha": "^10.0.6",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -25,9 +25,15 @@ export default [
   }),
   bundle({
     plugins: [dts()],
-    output: {
-      file: `lib/aes-cmac.d.ts`,
-      format: "es",
-    },
+    output: [
+      {
+        file: `lib/aes-cmac.d.mts`,
+        format: "es",
+      },
+      {
+        file: `lib/aes-cmac.d.cts`,
+        format: "cjs",
+      },
+    ],
   }),
 ];


### PR DESCRIPTION
This fixes typescript error TS7016:

> Could not find a declaration file for module 'aes-cmac'. '/projectDir/node_modules/.pnpm/aes-cmac@3.0.2/node_modules/aes-cmac/lib/aes-cmac.mjs' implicitly has an 'any' type.
There are types at '/projectDir/node_modules/aes-cmac/lib/aes-cmac.d.ts', but this result could not be resolved when respecting package.json "exports". The 'aes-cmac' library may need to update its package.json or typings. ts(7016)